### PR TITLE
Install specific notebook version as otherwise conda fails.

### DIFF
--- a/conda/environment_full.yaml
+++ b/conda/environment_full.yaml
@@ -16,7 +16,7 @@ dependencies:
   - ipython
   - ipykernel
   - jupyterlab
-  - notebook
+  - notebook==6.4.12
   - nb_conda_kernels
   - jupyter_contrib_nbextensions
   - pinocchio


### PR DESCRIPTION
I was trying to create a Conda environment with the full environment file, but it failed (related issue: #41). Installing a specific notebook version resolves the issue.