### PR TITLE
fix conda enviroment creation bug #41

### DIFF
--- a/conda/environment_full.yaml
+++ b/conda/environment_full.yaml
@@ -16,7 +16,7 @@ dependencies:
   - ipython
   - ipykernel
   - jupyterlab
-  - notebook
+  - notebook==6.4.12
   - nb_conda_kernels
   - jupyter_contrib_nbextensions
   - pinocchio


### PR DESCRIPTION
I opened issue #41 in August of last year, I still get notifications every few weeks, somebody runs into the same problem, let's patch this.

I had an error during environment setup
ModuleNotFoundError: No module named 'notebook.nbextensions' Solved it by locking the notebook package to a lower version. Updated environment_full.yaml to lock to a specific version.

notebook==6.4.12